### PR TITLE
change enum define to a typedef so that including header in multiple .m ...

### DIFF
--- a/iToast.h
+++ b/iToast.h
@@ -34,7 +34,7 @@ typedef enum iToastGravity {
 	iToastGravityCenter
 }iToastGravity;
 
-enum iToastDuration {
+typedef enum iToastDuration {
 	iToastDurationLong = 10000,
 	iToastDurationShort = 1000,
 	iToastDurationNormal = 3000


### PR DESCRIPTION
this enum define will cause duplicated symbol link error if the header is imported in multiple .m files.
please repair this bug whit this patch.