### PR TITLE
remove Static Analysis issue

### DIFF
--- a/iToast.m
+++ b/iToast.m
@@ -128,7 +128,7 @@ static iToastSettings *sharedSettings = nil;
 	
 	UIWindow *window = [[[UIApplication sharedApplication] windows] objectAtIndex:0];
 	
-	CGPoint point;
+	CGPoint point = CGPointZero;
 	
 	// Set correct orientation/location regarding device orientation
 	UIInterfaceOrientation orientation = (UIInterfaceOrientation)[[UIApplication sharedApplication] statusBarOrientation];


### PR DESCRIPTION
remove Static Analysis issue: 'Passed-by-value struct argument contains uninitialized data (e.g., field: 'x')'

Issue: Passed-by-value struct argument contains uninitialized data (e.g., field: 'x').
Description: Passed-by-value struct argument contains uninitialized data (e.g., field: 'x').